### PR TITLE
Change null response exception

### DIFF
--- a/PokemonGo.RocketAPI/Extensions/HttpClientExtensions.cs
+++ b/PokemonGo.RocketAPI/Extensions/HttpClientExtensions.cs
@@ -16,8 +16,8 @@ namespace PokemonGo.RocketAPI.Extensions
             Debug.WriteLine($"Requesting {typeof(TResponsePayload).Name}");
             var response = await PostProto<TRequest>(client, url, requestEnvelope);
 
-            if (response.Returns.Count == 0)
-                throw new InvalidResponseException();
+            while (response.Returns.Count == 0)
+                response = await PostProto<TRequest>(client, url, requestEnvelope);
 
             //Decode payload
             //todo: multi-payload support


### PR DESCRIPTION
During high load on PokeGo servers sometimes we're getting null response on first call.
If request was sent again, client gets proper response.
